### PR TITLE
fix(live): Remove arbitrary 30 second buffer when seeking to live

### DIFF
--- a/src/js/NativeHls.js
+++ b/src/js/NativeHls.js
@@ -319,7 +319,7 @@ class NativeHls extends Meister.MediaPlugin {
                 this.onRequestGoLive();
             });
         } else {
-            this.player.currentTime = this.endTime - 30;
+            this.player.currentTime = this.endTime - 1;
         }
     }
 


### PR DESCRIPTION
I figure it's probably better to let the player handle any buffering
issues itself.